### PR TITLE
Compare Spring 2015 to Spring 2016

### DIFF
--- a/01-download-GTFS.R
+++ b/01-download-GTFS.R
@@ -20,3 +20,6 @@ post_sr_gtfs <- read_gtfs("data/20160321_htx.zip",
                          local = TRUE,
                          geometry = TRUE,
                          frequency = TRUE)
+
+
+

--- a/01-download-GTFS.R
+++ b/01-download-GTFS.R
@@ -5,18 +5,18 @@
 library(tidytransit)
 
 # GTFS feeds obtained from transitfeeds.com
-# The “before” dataset represents service from May 23, 2015 to August 15, 2015 
-# and the “after” dataset represents service from August 16, 2015 to 
-# January 23, 2016. 
+# The “before” dataset represents service from the Spring 2015 service period (weekday) - 1/25/15 thru 6/6/15 -
+# and the “after” dataset represents service from the Spring 2016 service period (weekday) - 1/24/16 thru 5/28/16.
+# The actual system service change took place on August 16, 2015.
 # More information about System Reimagining is available here: 
 # https://www.ridemetro.org/Pages/Reimagining.aspx
 
-pre_sr_gtfs <- read_gtfs("data/20150517_htx.zip", 
+pre_sr_gtfs <- read_gtfs("data/20150323_htx.zip", 
                          local = TRUE,
                          geometry = TRUE,
                          frequency = TRUE)
 
-post_sr_gtfs <- read_gtfs("data/20150818_htx.zip", 
+post_sr_gtfs <- read_gtfs("data/20160321_htx.zip", 
                          local = TRUE,
                          geometry = TRUE,
                          frequency = TRUE)


### PR DESCRIPTION
Many transit agencies provide less (or different) transit service during the summer time vs. other time of year based on the absence of public school scheduled during this time. Rather than comparing the Spring 2015 to Summer 2015 (when the change most immediately occurred) I think it would be better to compare the same service period in consecutive years.